### PR TITLE
add new features

### DIFF
--- a/torrent-web/client/src/components/DownloadCard.tsx
+++ b/torrent-web/client/src/components/DownloadCard.tsx
@@ -12,7 +12,7 @@ interface DownloadCardProps {
 }
 
 function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
+  if (!bytes || bytes <= 0 || !isFinite(bytes)) return "0 B";
   const k = 1024;
   const sizes = ["B", "KB", "MB", "GB", "TB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
@@ -20,7 +20,7 @@ function formatBytes(bytes: number): string {
 }
 
 function formatSpeed(bytesPerSecond: number): string {
-  if (bytesPerSecond === 0) return "0 B/s";
+  if (!bytesPerSecond || bytesPerSecond <= 0 || !isFinite(bytesPerSecond)) return "0 B/s";
   return `${formatBytes(bytesPerSecond)}/s`;
 }
 

--- a/torrent-web/client/src/pages/Downloads.tsx
+++ b/torrent-web/client/src/pages/Downloads.tsx
@@ -19,6 +19,7 @@ export interface WebTorrentInfo {
   done: boolean;
   magnetURI: string;
   files: FileInfo[];
+  metadata?: { title: string; provider?: string; size?: string };
 }
 
 interface FileInfo {
@@ -35,7 +36,7 @@ interface DownloadsProps {
 }
 
 function formatSpeed(bytesPerSecond: number): string {
-  if (bytesPerSecond === 0) return "0 B/s";
+  if (!bytesPerSecond || bytesPerSecond <= 0 || !isFinite(bytesPerSecond)) return "0 B/s";
   const k = 1024;
   const sizes = ["B/s", "KB/s", "MB/s", "GB/s"];
   const i = Math.floor(Math.log(bytesPerSecond) / Math.log(k));

--- a/torrent-web/client/src/styles/main.css
+++ b/torrent-web/client/src/styles/main.css
@@ -587,6 +587,20 @@ body {
   }
 }
 
+.warmup-notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.warmup-notice .spinner {
+  margin: 0;
+  flex-shrink: 0;
+}
+
 /* Torrent Card - Row Style */
 .torrent-card {
   background: var(--bg-primary);

--- a/torrent-web/server/index.ts
+++ b/torrent-web/server/index.ts
@@ -211,10 +211,13 @@ app.get("/api/1337x/warmup-stream", async (c) => {
   });
 });
 
-// 1337x API status
+// 1337x API status (includes server-side warmup tracking)
 app.get("/api/1337x/status", async (c) => {
   const data = await leet.getStatus();
-  return c.json(data);
+  return c.json({
+    ...data,
+    warmup_in_progress: leet.isWarmupInProgress()
+  });
 });
 
 // Get magnet link

--- a/torrent-web/server/webtorrent.ts
+++ b/torrent-web/server/webtorrent.ts
@@ -60,6 +60,12 @@ function loadState(): PersistedState {
 // Store metadata for each torrent (by infoHash)
 const torrentMetadata: Record<string, { title: string; provider?: string; size?: string }> = {};
 
+// Track when each torrent was added (by infoHash) — preserved across saves
+const torrentAddedAt: Record<string, number> = {};
+
+// Track torrents that were complete when restored — used to override progress during verification
+const completedHashes = new Set<string>();
+
 function saveState() {
   try {
     const state: PersistedState = { torrents: {} };
@@ -68,8 +74,8 @@ function saveState() {
       state.torrents[torrent.infoHash] = {
         magnetURI: torrent.magnetURI,
         paused: torrent.paused,
-        addedAt: Date.now(),
-        done: torrent.done,
+        addedAt: torrentAddedAt[torrent.infoHash] || Date.now(),
+        done: torrent.done || completedHashes.has(torrent.infoHash),
         metadata: torrentMetadata[torrent.infoHash]
       };
     });
@@ -91,6 +97,16 @@ async function restoreTorrents() {
       // Restore metadata if available
       if (torrentState.metadata) {
         torrentMetadata[infoHash] = torrentState.metadata;
+      }
+
+      // Restore addedAt timestamp
+      if (torrentState.addedAt) {
+        torrentAddedAt[infoHash] = torrentState.addedAt;
+      }
+
+      // Track completed torrents so we can override progress during verification
+      if (torrentState.done) {
+        completedHashes.add(infoHash);
       }
 
       // If torrent was complete, pause it after adding to prevent re-verification/seeding
@@ -126,6 +142,7 @@ export interface TorrentInfo {
   done: boolean;
   files: FileInfo[];
   magnetURI: string;
+  metadata?: { title: string; provider?: string; size?: string };
 }
 
 export interface FileInfo {
@@ -140,21 +157,24 @@ export interface FileInfo {
 function formatTorrentInfo(torrent: WebTorrent.Torrent): TorrentInfo {
   // Handle case where files haven't loaded yet (during metadata fetch)
   const files = torrent.files || [];
+  const isKnownComplete = completedHashes.has(torrent.infoHash);
 
   return {
     infoHash: torrent.infoHash,
     name: torrent.name || "Loading...",
-    progress: torrent.progress || 0,
-    downloadSpeed: torrent.downloadSpeed || 0,
-    uploadSpeed: torrent.uploadSpeed || 0,
+    // Override progress/speed for completed torrents during re-verification
+    progress: isKnownComplete ? 1 : torrent.progress || 0,
+    downloadSpeed: isKnownComplete ? 0 : torrent.downloadSpeed || 0,
+    uploadSpeed: isKnownComplete ? 0 : torrent.uploadSpeed || 0,
     numPeers: torrent.numPeers || 0,
     downloaded: torrent.downloaded || 0,
     uploaded: torrent.uploaded || 0,
     totalSize: torrent.length || 0,
-    timeRemaining: torrent.timeRemaining || Infinity,
+    timeRemaining: isKnownComplete ? 0 : torrent.timeRemaining || Infinity,
     paused: torrent.paused || false,
-    done: torrent.done || false,
+    done: isKnownComplete ? true : torrent.done || false,
     magnetURI: torrent.magnetURI,
+    metadata: torrentMetadata[torrent.infoHash],
     files: files.map((file, index) => ({
       name: file.name,
       path: file.path,
@@ -202,9 +222,14 @@ export async function addTorrent(
       // Store metadata if provided
       if (options.metadata) {
         torrentMetadata[torrent.infoHash] = options.metadata;
-      } else {
-        // Store name as fallback metadata
+      } else if (!torrentMetadata[torrent.infoHash]) {
+        // Store name as fallback metadata only if not already set (e.g. from restore)
         torrentMetadata[torrent.infoHash] = { title: torrent.name || "Unknown" };
+      }
+
+      // Record addedAt if not already set
+      if (!torrentAddedAt[torrent.infoHash]) {
+        torrentAddedAt[torrent.infoHash] = Date.now();
       }
 
       // If should be paused (either explicitly or was complete), pause it
@@ -216,7 +241,8 @@ export async function addTorrent(
       }
 
       // Prioritize first and last pieces for streaming
-      if (torrent.files.length > 0) {
+      // Skip for completed torrents to avoid triggering verification activity
+      if (torrent.files.length > 0 && !options.wasComplete) {
         const mainFile = torrent.files.reduce((a, b) => (a.length > b.length ? a : b));
         // Select the main file for download
         mainFile.select();
@@ -280,6 +306,8 @@ export function pauseTorrent(infoHash: string): boolean {
 export function resumeTorrent(infoHash: string): boolean {
   const torrent = client.torrents.find((t) => t.infoHash === infoHash);
   if (torrent) {
+    // Remove from completedHashes so real progress is reported again
+    completedHashes.delete(infoHash);
     torrent.resume();
     saveState();
     return true;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core search gating and server-side download state/persistence; regressions could block searches during warmup or misreport download completion/progress after restart.
> 
> **Overview**
> Search flows now wait for the 1337x Cloudflare warmup to finish before calling `/api/search`, showing a small in-UI “waiting for bypass” notice in `Search` and `ContentDetail`. `CloudflareStatus` exports `isWarmupActive`/`waitForWarmup` and shares warmup state across components by polling `/api/1337x/status` when needed.
> 
> On the server, 1337x warmup calls are deduplicated via a singleton `activeWarmup`, and `/api/1337x/status` now reports `warmup_in_progress`.
> 
> WebTorrent persistence is tightened: `addedAt` is preserved across saves/restores, completed torrents restored from disk are tracked to avoid misleading progress/speed during verification, metadata is surfaced in API responses, and torrent removal now cleans up any stale in-memory state. Minor UI robustness fixes treat invalid/negative byte and speed values as `0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 798031f818667c7f5e63a8ee6cee660272f4f58a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->